### PR TITLE
sets up publishing via CircleCI

### DIFF
--- a/.bin/version.js
+++ b/.bin/version.js
@@ -1,0 +1,3 @@
+var pkg = require('./../package.json');
+
+console.log(pkg.version);

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  node:
+    version: 5.5.0
+
+# CircleCI bundles node 5.5.0 w/ npm 2.13.5, whereas node itself advertises
+# that 5.5.0 works w/ npm 3.3.12
+# https://discuss.circleci.com/t/wrong-npm-version-with-node-5-0-5-1/827/3
+# https://nodejs.org/en/download/releases/
+dependencies:
+  pre:
+    - npm install -g npm-cli-login@0.0.10 npm@3.3.12
+    - NPM_USER=$NPM_USERNAME NPM_PASS=$NPM_PASSWORD npm-cli-login
+
+deployment:
+  production:
+    branch: master
+    commands:
+      - npm --no-git-tag-version version `git describe --abbrev=0`
+      - npm --no-git-tag-version version patch
+      - git config --global user.email $GIT_EMAIL
+      - git config --global user.name $GIT_USERNAME
+      - git tag -a v`node .bin/version.js` -m v`node .bin/version.js`
+      - npm publish
+      - git push --tags

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-registry-utils",
+  "name": "@chronicled/open-registry-utils",
   "version": "0.0.1",
   "description": "Utils library for open-registry apps.",
   "main": "index.js",


### PR DESCRIPTION
In addition to these changes I've pushed the tag "v0.0.0" to serve as the seed for the publication process. This tag will be applied to the project and then incremented so the first published version will be v0.0.1.
