### PR TITLE
puts back npm login

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,8 @@ machine:
 # https://nodejs.org/en/download/releases/
 dependencies:
   pre:
-    - npm install -g npm@3.3.12
+    - npm install -g npm-cli-login@0.0.10 npm@3.3.12
+    - NPM_USER=$NPM_USERNAME NPM_PASS=$NPM_PASSWORD npm-cli-login
 
 deployment:
   production:


### PR DESCRIPTION
- need it to publish
- this aims to fix the error from this build: https://circleci.com/gh/chronicled/open-registry-utils/6
