### PR TITLE
CHRON-4022 -- ID Hex Encoding Fix

### DIFF
--- a/lib/urn.js
+++ b/lib/urn.js
@@ -13,8 +13,21 @@
 // limitations under the License.
 
 const MAX_HEX_ID_LENGTH = 65535;
+const RECOGNIZED_PROTOCOLS = new Set([
+  'pbk:ec:secp256r1',
+  'pbk:rsa:2048',
+  'ble:1\.0',
+  'nfc:1\.0',
+  'sn',
+  'hash:argon',
+  'hash:id'
+]);
 
 module.exports = {
+  recognizedProtocols: Array.from(RECOGNIZED_PROTOCOLS),
+  isRecognizedProtocol: function(protocol) {
+    return RECOGNIZED_PROTOCOLS.has(protocol);
+  },
   split: function(urn) {
     var err = this.check(urn);
 
@@ -31,16 +44,7 @@ module.exports = {
     }
   },
   check: function(urns) {
-    var allowedProtocols = [
-      'pbk:ec:secp256r1',
-      'pbk:rsa:2048',
-      'ble:1\.0',
-      'nfc:1\.0',
-      'sn',
-      'hash:argon',
-      'hash:id'
-    ];
-    var allowedProtocolsRegExp = new RegExp('^' + allowedProtocols.join(':[^:]+$|^') + ':[^:]+$');
+    var allowedProtocolsRegExp = new RegExp('^' + this.recognizedProtocols.join(':[^:]+$|^') + ':[^:]+$');
     if (typeof urns === 'string') {
       urns = [urns];
     }
@@ -158,13 +162,15 @@ module.exports = {
       var schema = identity.slice(0, schemaLength);
       var id = identity.slice(schemaLength + 1);
       var schemaHex = stringToHex(schema);
-      var idHex = stringToHex(id);
+      var idHex = RECOGNIZED_PROTOCOLS.has(schema) ? id : stringToHex(id);
       var idLength = idHex.length / 2;
 
       if (idLength <= 0) {
         throw new Error('ID is empty');
       } else if (idLength > MAX_HEX_ID_LENGTH) {
         throw new Error(`Maximum length of ID is ${MAX_HEX_ID_LENGTH}`);
+      } else if (idLength != idLength.toFixed()) {
+        throw new Error('Hex chars are of odd count');
       }
 
       var schemaPart = ('0' + schemaLength.toString(16)).slice(-2) + schemaHex;
@@ -207,8 +213,8 @@ module.exports = {
         var schema = encoded.slice(nextIndex + 1 * 2, nextIndex + (1 + schemaLength) * 2);
         // Convert to string
         schema = hexToString(schema);
-        var id = encoded.slice(nextIndex + (1 + schemaLength + 2) * 2, nextIndex + (1 + schemaLength + 2 + idLength) * 2);
-
+        var idHex = encoded.slice(nextIndex + (1 + schemaLength + 2) * 2, nextIndex + (1 + schemaLength + 2 + idLength) * 2);
+        var id = RECOGNIZED_PROTOCOLS.has(schema) ? idHex : hexToString(idHex);
         result.push(schema + ':' + id);
 
         // Get full cells

--- a/lib/urn.js
+++ b/lib/urn.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const MAX_HEX_ID_LENGTH = 65535;
+
 module.exports = {
   split: function(urn) {
     var err = this.check(urn);
@@ -149,31 +151,26 @@ module.exports = {
 
       if (schemaLength <= 0) {
         throw new Error('Wrong fomatting');
-      }
-
-      if (schemaLength > 255) {
+      } else if (schemaLength > 255) {
         throw new Error('Maximum length of URN schema is 255');
       }
 
-      // Each hex char is 4 bits
-      var idLength = (identity.length - schemaLength - 1) / 2;
-
-      if (idLength != idLength.toFixed()) {
-        throw new Error('Hex chars are of odd count');
-      }
+      var schema = identity.slice(0, schemaLength);
+      var id = identity.slice(schemaLength + 1);
+      var schemaHex = stringToHex(schema);
+      var idHex = stringToHex(id);
+      var idLength = idHex.length / 2;
 
       if (idLength <= 0) {
         throw new Error('ID is empty');
+      } else if (idLength > MAX_HEX_ID_LENGTH) {
+        throw new Error(`Maximum length of ID is ${MAX_HEX_ID_LENGTH}`);
       }
 
-      if (idLength > 65535) {
-        throw new Error('Maximum length of ID is 65535');
-      }
+      var schemaPart = ('0' + schemaLength.toString(16)).slice(-2) + schemaHex;
+      var idPart = ('000' + idLength.toString(16)).slice(-4) + idHex;
+      return schemaPart + idPart;
 
-      return ('0' + schemaLength.toString(16)).slice(-2) +
-             stringToHex(identity.slice(0, schemaLength)) +
-             ('000' + idLength.toString(16)).slice(-4) +
-             identity.slice(schemaLength + 1);
     },
     chunk: function(hex) {
       var chunks = hex.match(/.{2,64}/g);

--- a/lib/urn.js
+++ b/lib/urn.js
@@ -13,20 +13,21 @@
 // limitations under the License.
 
 const MAX_HEX_ID_LENGTH = 65535;
-const RECOGNIZED_PROTOCOLS = new Set([
-  'pbk:ec:secp256r1',
-  'pbk:rsa:2048',
+const RECOGNIZED_PROTOCOLS = [
+  'pbk:ec',
+  'pbk:rsa',
   'ble:1\.0',
   'nfc:1\.0',
   'sn',
   'hash:argon',
   'hash:id'
-]);
+];
+const allowedProtocolsRegExp = new RegExp('^' + RECOGNIZED_PROTOCOLS.join('.*$|^') + '.*$');
 
 module.exports = {
-  recognizedProtocols: Array.from(RECOGNIZED_PROTOCOLS),
-  isRecognizedProtocol: function(protocol) {
-    return RECOGNIZED_PROTOCOLS.has(protocol);
+  recognizedProtocols: RECOGNIZED_PROTOCOLS,
+  isRecognizedProtocol: function(urn) {
+    return urn.match(allowedProtocolsRegExp);
   },
   split: function(urn) {
     var err = this.check(urn);
@@ -44,7 +45,6 @@ module.exports = {
     }
   },
   check: function(urns) {
-    var allowedProtocolsRegExp = new RegExp('^' + this.recognizedProtocols.join(':[^:]+$|^') + ':[^:]+$');
     if (typeof urns === 'string') {
       urns = [urns];
     }
@@ -162,7 +162,7 @@ module.exports = {
       var schema = identity.slice(0, schemaLength);
       var id = identity.slice(schemaLength + 1);
       var schemaHex = stringToHex(schema);
-      var idHex = RECOGNIZED_PROTOCOLS.has(schema) ? id : stringToHex(id);
+      var idHex = identity.match(allowedProtocolsRegExp) ? id : stringToHex(id);
       var idLength = idHex.length / 2;
 
       if (idLength <= 0) {
@@ -214,7 +214,7 @@ module.exports = {
         // Convert to string
         schema = hexToString(schema);
         var idHex = encoded.slice(nextIndex + (1 + schemaLength + 2) * 2, nextIndex + (1 + schemaLength + 2 + idLength) * 2);
-        var id = RECOGNIZED_PROTOCOLS.has(schema) ? idHex : hexToString(idHex);
+        var id = schema.match(allowedProtocolsRegExp) ? idHex : hexToString(idHex);
         result.push(schema + ':' + id);
 
         // Get full cells

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
     "ezcrypto": "0.0.3",
     "jsrsasign": "^5.0.12"
   },
+  "eslintConfig": {
+    "env": {
+      "node": true,
+      "es6": true
+    }
+  },
   "devDependencies": {
     "babel-core": "^6.13.2",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
As explained in [issue 4022](https://chronicled-co.atlassian.net/browse/CHRON-4022), the current encoding process for URNs will fail if the ID length is not equal to an even number of chars. When a recent attempt to register the following URN failed:
```
urn:epc:id:sgtin:0371234.001001.81000003160872
```
It was decided the the SDK should be made more flexible and convenient for end users and that it should be able to take the URN shown above and properly encode it. As a result, I refactored the encoding process so that it attempts to encode the ID section of the URN from a UTF String to a Hex String (it seemed previously that the logic assumed the ID section was already a Hex String, which is why it failed for an odd number of chars). Creating a Thing with the URN shown above was successful after the refactor and I was also able to lookup the Thing by its URN using the consumer SDK, so the encoding and decoding functionality was preserved. 