### PR TITLE
ec-curve-support

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var urnLib = require('./urn');
-var ecLib = require('./ec');
+const urnLib = require('./urn');
+const ecLib = require('./ec');
+const _ = require('lodash');
 
 module.exports = {
   compressAll: function(urns) {
@@ -21,9 +22,11 @@ module.exports = {
       urns = [urns];
     }
     var compressed = urns.map(function(urn) {
-      var splitResult = urnLib.split(urn);
-      if(splitResult.subCats && splitResult.subCats[0] === 'ec' && splitResult.id.slice(0, 2) === '04') {
-        return urnLib.create(splitResult.cat, splitResult.subCats, ecLib.compress(splitResult.id));
+      const parsed = urnLib.split(urn);
+      const canCompress = _.last(parsed.subCats || []) === 'secp256r1';
+
+      if(canCompress && parsed.id.slice(0, 2) === '04') {
+        return urnLib.create(parsed.cat, parsed.subCats, ecLib.compress(parsed.id));
       }
       return urn;
     });

--- a/lib/ec.js
+++ b/lib/ec.js
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var BigInteger = require('bigi');
-var Crypto = require('ezcrypto').Crypto;
-var jsrsasign = require('jsrsasign');
-var urn = require('./urn');
+const BigInteger = require('bigi');
+const Crypto = require('ezcrypto').Crypto;
+const jsrsasign = require('jsrsasign');
+const urn = require('./urn');
+const _ = require('lodash');
+
+const ecCurves = {};
 
 module.exports = {
   getYbyX: function(xInHex, isYEven) {
@@ -43,9 +46,11 @@ module.exports = {
   },
 
   verify: function(identityURN, hashHex, sigHex) {
-    var publicKeyHex = this.getPlainPubKey(urn.split(identityURN).id);
-    var ec = new jsrsasign.ECDSA({'curve': 'secp256r1'});
-    return ec.verifyHex(hashHex, sigHex, publicKeyHex);
+    const parsed = urn.split(identityURN);
+    const curve = _.last(parsed.subCats);
+    const publicKeyHex = curve === 'secp256r1' ? this.getPlainPubKey(parsed.id) : parsed.id;
+    ecCurves[curve] = ecCurves[curve] || new jsrsasign.ECDSA({curve});
+    return ecCurves[curve].verifyHex(hashHex, sigHex, publicKeyHex);
   },
 
   isCompressed: function(publicKey) {

--- a/lib/urn.js
+++ b/lib/urn.js
@@ -14,15 +14,17 @@
 
 const MAX_HEX_ID_LENGTH = 65535;
 const RECOGNIZED_PROTOCOLS = [
-  'pbk:ec',
-  'pbk:rsa',
+  //last part should be curve
+  'pbk:ec:[a-zA-Z0-9]+',
+  //last curve should be RSA key size
+  'pbk:rsa:[0-9]+',
   'ble:1\.0',
   'nfc:1\.0',
   'sn',
   'hash:argon',
   'hash:id'
 ];
-const allowedProtocolsRegExp = new RegExp('^' + RECOGNIZED_PROTOCOLS.join('.*$|^') + '.*$');
+const allowedProtocolsRegExp = new RegExp('^' + RECOGNIZED_PROTOCOLS.join('|^'));
 
 module.exports = {
   recognizedProtocols: RECOGNIZED_PROTOCOLS,
@@ -50,87 +52,13 @@ module.exports = {
     }
     for (var index in urns) {
       var urn = urns[index];
-      if (!urn.match(allowedProtocolsRegExp) && urn.match(/^([^:]+:)+[^:]+$/)) {
+      var validUrnRegExp = /^([^:]+:)+[^:]+$/;
+      if (urn.match(validUrnRegExp)) {
         return true;
-      }
-
-      // Parse ID portion of URN
-      var cat = urn.split(':').slice(0, -1)
-      var id = urn.split(':').slice(-1)[0];
-
-      if (id.length % 2 !== 0) {
-        return 'Identity must have even length and be in proper format';
-      }
-
-      // Split identity by each byte
-      var charArr = id.match(/.{1,2}/g);
-
-      // Match category of URN
-      switch (cat) {
-        case 'pbk:ec:secp256r1':
-          // Check for compressed/uncompressed ECDSA public keys
-          if (charArr[0] === '02' || charArr[0] === '03') {
-            // Check length of compressed public key
-            if (charArr.length !== 33) {
-              return 'Incorrect compressed public key byte length: Compressed public keys are 33 bytes long: 32 bytes for coordinate, 1 byte for coordinate sign';
-            }
-          } else if (charArr[0] === '04') {
-            // Check length of uncompressed public key
-            if (charArr.length !== 65) {
-              return 'Incorrect uncompressed public key byte length: Uncompressed keys should be 1 byte + 32 bytes for x coordinate + 32 bytes for x coordinate';
-            }
-          }
-
-          break;
-        case 'pbk:rsa:2048':
-          // Grab RSA exponent if it exists
-          if (id.length < 512) {
-            return 'Improper data length, should be 2048 bits compressed into 256 bytes';
-          } else if (id.length > 512) {
-            exponent = id.substring(512, id.length);
-            if (exponent.length % 2 !== 0) {
-              return 'Improper exponent length, should be even character count in hex format';
-            }
-          }
-
-          break;
-
-        // BLE ids are standardized with a 6 bytes MAC address
-        case 'ble:1\.0':
-          if (charArr.length !== 6) {
-            return 'Incorrect BLE identity, BLE ids are standardized at a fixed 6 byte length';
-          }
-
-          break;
-
-        // NFC ids come in 4,7, and 10 bytes variants
-        // Validation specs: www.nxp.com/documents/application_note/AN10927.pdf
-        case 'nfc:1\.0':
-          if (charArr.length === 4) {
-            // UID0 byte cannot be '0x88'
-            if (charArr[0] === '88') {
-              return 'Incorrect NFC identity specification: Wrong first byte';
-            }
-          } else if (charArr.length === 7 || charArr.length === 10) {
-            // UID3 byte cannot be '0x88'
-            if (charArr[3] === '88') {
-              return 'Incorrect NFC identity specification: Wrong third byte';
-            }
-          } else {
-            return 'Incorrect NFC identity specification: Wrong byte length';
-          }
-
-          break;
-        case 'sn':
-          break;
-        case 'hash:argon':
-          break;
-        case 'hash:id':
-          break;
+      } else {
+        return "Invalid URN format";
       }
     }
-
-    return true;
   },
   create: function(cat, subCats, id) {
     var newURN = cat;

--- a/lib/urn.js
+++ b/lib/urn.js
@@ -55,6 +55,72 @@ module.exports = {
       var validUrnRegExp = /^([^:]+:)+[^:]+$/;
       if (urn.match(validUrnRegExp)) {
         return true;
+        //TODO: Re-introduce stricter validation of URNs
+        // Parse ID portion of URN
+        // var cat = urn.split(':').slice(0, -1)
+        // var id = urn.split(':').slice(-1)[0];
+        //
+        // if (id.length % 2 !== 0) {
+        //   return 'Identity must have even length and be in proper format';
+        // }
+        //
+        // // Split identity by each byte
+        // var charArr = id.match(/.{1,2}/g);
+        //
+        // // Match category of URN
+        // switch (cat) {
+        //   case 'pbk:ec:secp256r1':
+        //     // Check for compressed/uncompressed ECDSA public keys
+        //     if (charArr[0] === '02' || charArr[0] === '03') {
+        //       // Check length of compressed public key
+        //       if (charArr.length !== 33) {
+        //         return 'Incorrect compressed public key byte length: Compressed public keys are 33 bytes long: 32 bytes for coordinate, 1 byte for coordinate sign';
+        //       }
+        //     } else if (charArr[0] === '04') {
+        //       // Check length of uncompressed public key
+        //       if (charArr.length !== 65) {
+        //         return 'Incorrect uncompressed public key byte length: Uncompressed keys should be 1 byte + 32 bytes for x coordinate + 32 bytes for x coordinate';
+        //       }
+        //     }
+        //
+        //     break;
+        //   case 'pbk:rsa:2048':
+        //     // Grab RSA exponent if it exists
+        //     if (id.length < 512) {
+        //       return 'Improper data length, should be 2048 bits compressed into 256 bytes';
+        //     } else if (id.length > 512) {
+        //       exponent = id.substring(512, id.length);
+        //       if (exponent.length % 2 !== 0) {
+        //         return 'Improper exponent length, should be even character count in hex format';
+        //       }
+        //     }
+        //
+        //     break;
+        //
+        //   // BLE ids are standardized with a 6 bytes MAC address
+        //   case 'ble:1\.0':
+        //     if (charArr.length !== 6) {
+        //       return 'Incorrect BLE identity, BLE ids are standardized at a fixed 6 byte length';
+        //     }
+        //
+        //     break;
+        //
+        //   // NFC ids come in 4,7, and 10 bytes variants
+        //   // Validation specs: www.nxp.com/documents/application_note/AN10927.pdf
+        //   case 'nfc:1\.0':
+        //     if (charArr.length === 4) {
+        //       // UID0 byte cannot be '0x88'
+        //       if (charArr[0] === '88') {
+        //         return 'Incorrect NFC identity specification: Wrong first byte';
+        //       }
+        //     } else if (charArr.length === 7 || charArr.length === 10) {
+        //       // UID3 byte cannot be '0x88'
+        //       if (charArr[3] === '88') {
+        //         return 'Incorrect NFC identity specification: Wrong third byte';
+        //       }
+        //     } else {
+        //       return 'Incorrect NFC identity specification: Wrong byte length';
+        //    }
       } else {
         return "Invalid URN format";
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "bigi": "^1.4.1",
     "ecurve": "^1.0.3",
     "ezcrypto": "0.0.3",
-    "jsrsasign": "^5.0.12"
+    "jsrsasign": "^5.0.12",
+    "lodash": "^4.17.4"
   },
   "eslintConfig": {
     "env": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utils library for open-registry apps.",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js",
+    "test": "mocha test.js",
     "lint": "./node_modules/.bin/eslint lib/**/*.js"
   },
   "repository": {
@@ -34,8 +34,10 @@
   "devDependencies": {
     "babel-core": "^6.13.2",
     "babel-loader": "^6.2.4",
-    "eslint": "2.13.1",
     "babel-preset-es2015": "^6.13.2",
+    "eslint": "2.13.1",
+    "mocha": "^3.4.2",
+    "should": "^11.2.1",
     "webpack": "^1.13.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -76,35 +76,11 @@ describe("URN Utils", () => {
   });
 
   it("should return a string message for invalid urns", () => {
-    should(utils.urn.check('pbk')).be.String();
-    // should(utils.urn.check('pbk:')).be.String();
-    // should(utils.urn.check('pbk::ec')).be.String();
-    // should(utils.urn.check(':pbk:ec')).be.String();
-    // should(utils.urn.check(':')).be.String();
-    // should(utils.urn.check('')).be.String();
-    // should(utils.urn.check('pbk:ec:secp256r11')).be.String();
-    // should(utils.urn.check('pbk:ec:secp256r1')).be.String();
-    // should(utils.urn.check('pbk:ec:secp256r1:something:id')).be.String();
-    // should(utils.urn.check('pbk:ec:secp256r2:123')).be.String();
-    // should(utils.urn.check('pbk:rsa:20480')).be.String();
-    // should(utils.urn.check('pbk:rsa:2048')).be.String();
-    // should(utils.urn.check('pbk:rsa:2048:something:id')).be.String();
-    // should(utils.urn.check('pbk:rsa:512')).be.String();
-    // should(utils.urn.check('ble:1.01')).be.String();
-    // should(utils.urn.check('ble:1.0')).be.String();
-    // should(utils.urn.check('ble:3.0')).be.String();
-    // should(utils.urn.check('ble:1.0:whatever:11223344')).be.String();
-    // should(utils.urn.check('nfc:1.01')).be.String();
-    // should(utils.urn.check('nfc:1.0')).be.String();
-    // should(utils.urn.check('nfc:1.0:something:id')).be.String();
-    // should(utils.urn.check('nfc:2.0')).be.String();
-    // should(utils.urn.check('snu:123')).be.String();
-    // should(utils.urn.check('sn:')).be.String();
-    // should(utils.urn.check('sn:something:id')).be.String();
-    // should(utils.urn.check('sn')).be.String();
-    // should(utils.urn.check('pbk:rsa:2048:123')).be.String();
-    // should(utils.urn.check('ble:1.0:123')).be.String();
-    // should(utils.urn.check('nfc:1.0:123')).be.String();
-    // should(utils.urn.check('sn:123')).be.String();
+    const invalidUrns = [
+      'pbk', 'pbk:', 'pbk::ec', ':pbk:ec', ':', ''
+    ];
+    invalidUrns.map(invalid => {
+      should(utils.urn.check(invalid)).be.String();
+    });
   });
 });

--- a/test.js
+++ b/test.js
@@ -12,93 +12,99 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var utils = require('./index.js');
+const utils = require('./index.js');
+const should = require('should');
 
-// Example keys.
-// Todo: generate keys dynamically
+describe("EC Utils: ", () => {
+  // Example keys.
+  // Todo: generate keys dynamically
+  const XYkeys = [
+    ['08e07141e07e622242f954dc89b656597a23a4dd3d212987c8cc0d827deccf7b', '704e94fb02bf21f54f622a9cdcb6a34981b91735d8227120a11c1b7eee983c51'],
+    ['0b6a054d8270713c90f8b2bffe82430ed3e9dcc3ba85dd578f8de78acecdcb40', 'd0421fbf709d2678be6388290027c61d37d7845deb13ac96c6ec872c36236241'],
+    ['644c762399ba9fcf2d8e144102cbbe94f2f034a3150846c3a09d7e146ff93559', '7f7ec2aab87182cf27f1d401b73c88578618e624eec99c5019e25f2f5b5acc90'],
+  ]
+  it("should correctly derive the Y coordinate from the X coordinate", () => {
+    XYkeys.map(keys => {
+      const [xKey, yKey] = keys;
+      // console.log(ec.getYbyX(key[0]), ec.hexToBigInteger(key[1]).isEven() );
+      should(utils.ec.getYbyX(xKey, utils.ec.hexToBigInteger(yKey).isEven())).equal(yKey.toUpperCase());
+    } )
+  })
+  it("should correctly compress and decompress coordinates", () => {
+    XYkeys.map(key => {
+      const uncompressed = '04' + key[0] + key[1];
+      should(utils.ec.decompressToCoordinate(utils.ec.compressCoordinate(key[0], key[1])).y).equal(key[1].toUpperCase());
+      should(utils.ec.decompress(utils.ec.compress(uncompressed)).toLowerCase()).equal(uncompressed.toLowerCase());
+    });
+  });
 
-// X, Y
-var keys = [
-  ['08e07141e07e622242f954dc89b656597a23a4dd3d212987c8cc0d827deccf7b', '704e94fb02bf21f54f622a9cdcb6a34981b91735d8227120a11c1b7eee983c51'],
-  ['0b6a054d8270713c90f8b2bffe82430ed3e9dcc3ba85dd578f8de78acecdcb40', 'd0421fbf709d2678be6388290027c61d37d7845deb13ac96c6ec872c36236241'],
-  ['644c762399ba9fcf2d8e144102cbbe94f2f034a3150846c3a09d7e146ff93559', '7f7ec2aab87182cf27f1d401b73c88578618e624eec99c5019e25f2f5b5acc90'],
-]
-console.log('Test EC utils:');
-keys.map( function( key ) {
-  // console.log(ec.getYbyX(key[0]), ec.hexToBigInteger(key[1]).isEven() );
-  console.log( utils.ec.getYbyX(key[0], utils.ec.hexToBigInteger(key[1]).isEven() ) == key[1].toUpperCase() )
-} )
+  it("should verify a given ec public key, challenge, and signature", () => {
+    const compressed = 'pbk:ec:secp256r1:0360FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6';
+    const uncompressed = 'pbk:ec:secp256r1:0492b0a5466a6711eedcaa63692150631c781542d5958b56ab4a52a91f8455ac2cff37d1518c918255a305cf1b84894a547a1697153fc506e0af1e8357c039692a';
+    should(utils.ec.verify(compressed, 'af2bdbe1aa9b6ec1e2ade1d694f41fc71a831d0268e9891562113d8a62add1bf','3046022100efd48b2aacb6a8fd1140dd9cd45e81d69d2c877b56aaf991c34d0ea84eaf3716022100f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8')).equal(true);
+    should(utils.ec.verify(compressed, 'af2bdbe1aa9b6ec1e2ade1d694441fc71a831d0268e9891562113d8a62add1bf','3046022100efd48b2aacb6a8fd1140dd9cd45e81d69d2c877b56aaf991c34d0ea84eaf3716022100f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8')).equal(false);
+    should(utils.ec.verify(uncompressed, '2ed24287293442f80e70b48d80edc9e5417760461f2e22ec70fe034d72e1b589','3045022100e475420623be422cbb178ae49c2e358bdfd442a994f77bf8238c93b4c3dc6ee1022040dd414d8bbb1dc8aa07baa9c6c400762fa9acacdaf5ad095060dc62f4dc16c2')).equal(true);
+  });
 
-keys.map( function( key ) {
-  console.log( utils.ec.decompressToCoordinate( utils.ec.compressCoordinate(key[0], key[1]) ).y  == key[1].toUpperCase() )
-} )
+  it("should create a new urn from a valid ec public key", () => {
+    const newKeyPair = utils.keyPair.generate('secp256r1');
+    const pubKeyCompress = utils.ec.compress(newKeyPair.ecpubhex);
+    const newURN = utils.urn.create('pbk',['ec','secp256r1'],pubKeyCompress);
+    should(newURN).startWith('pbk:ec:secp256r1');
+  });
+});
 
-keys.map( function( key ) {
-  var uncompressed = '04' + key[0] + key[1];
-  console.log(utils.ec.decompress( utils.ec.compress(uncompressed) ).toLowerCase()  == uncompressed.toLowerCase());
-} )
+describe("RSA Utils", () => {
+  it("should verify RSA key, challenge, and signature", () => {
+    const urn = 'pbk:rsa:2048:cb47e6aada931986bb6bbf02c8618437c072cefa4e19c1ee6cb189b95a49e3ce94fb4de129c30ab7e683f827c98eb05e844af24f809ed5f217e93c14d58f64b98fc9136d3c2b56a672853a8f52c7ac7acd201b09d0f578f32f377f954905e18fa360448901d0ac538cd1102dc0821cd13a843e370471c00e95daf4bba001186c5b2220e15f2f4777aa9b0a823186c34d82fd557e245b4d5816f48bdc09dd34806982609b63012dd13fe603f23730940e68463b1b68f24ee77907925d286d55ec22bad53119f8354388e051854ef436589538f1efbf104af477dc3ca2cf29974fcf432639b8716c38c717d44c8f0c90d59f02f2ab0aef8b59c2feb460e2cbfb57010001';
+    const urnWithoutExponent = urn.slice(0, -6);
+    const challenge = 'e3ecf72fa4143b3416154b62d0b570609d13f080';
+    const wrongChallenge = 'e3ecf72fa4143b3416154b62d0b570609d13f081';
+    const signature = '2f6b41e6091269af8782b0b3e62f00cadd9c724c4ed50fd1c5f04bb1ea45796d71192ea297b0b1c161ae619243eecaaf20794e0abc397705e357941435fcdbcf45b9dc955ae5a366eb4b991a947941f0a94e41b81c4c13453f0ca0230ba6063d7f79f437c2ea26db40d6eafaecf6df7565b6a7673b05d5c5ff6d9420c4acb72a8905f6f79e9026940ce9c8d38c96dbf5a0388d3965caea316456553fbf4818c12c213c88015eaf2930148d7b23a57a71994bdea5113f661a24b6fe74d6fd347d41a0c63638be28f8410d4c1cd441fc38b5a0d4bbee1410babe5b4e5768a55f1f321354acecaf9e14981434bbe1c72fcfb0153b94141f6c48198f3890f95e8ce3';
+    should(utils.rsa.verify(urn, challenge, signature)).equal(true);
+    should(utils.rsa.verify(urnWithoutExponent, challenge, signature)).equal(true);
+    should(utils.rsa.verify(urn, wrongChallenge, signature)).equal(false);
+  });
+});
 
-// TODO: change from "should be" to assert or at least a == b, where result must be true if it works
-console.log('');
-console.log('Verify EC:','af2bdbe1aa9b6ec1e2ade1d694f41fc71a831d0268e9891562113d8a62add1bf ; 3046022100efd48b2aacb6a8fd1140dd9cd45e81d69d2c877b56aaf991c34d0ea84eaf3716022100f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8 ; pbk:ec:secp256r1:0360FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6');
-console.log('should be true:',utils.ec.verify('pbk:ec:secp256r1:0360FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6', 'af2bdbe1aa9b6ec1e2ade1d694f41fc71a831d0268e9891562113d8a62add1bf','3046022100efd48b2aacb6a8fd1140dd9cd45e81d69d2c877b56aaf991c34d0ea84eaf3716022100f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8'))
-console.log('should be false:',utils.ec.verify('pbk:ec:secp256r1:0360FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6', 'af2bdbe1aa9b6ec1e2ade1d694441fc71a831d0268e9891562113d8a62add1bf','3046022100efd48b2aacb6a8fd1140dd9cd45e81d69d2c877b56aaf991c34d0ea84eaf3716022100f7cb1c942d657c41d436c7a1b6e29f65f3e900dbb9aff4064dc4ab2f843acda8'))
-console.log('should be true:', utils.ec.verify('pbk:ec:secp256r1:0492b0a5466a6711eedcaa63692150631c781542d5958b56ab4a52a91f8455ac2cff37d1518c918255a305cf1b84894a547a1697153fc506e0af1e8357c039692a', '2ed24287293442f80e70b48d80edc9e5417760461f2e22ec70fe034d72e1b589','3045022100e475420623be422cbb178ae49c2e358bdfd442a994f77bf8238c93b4c3dc6ee1022040dd414d8bbb1dc8aa07baa9c6c400762fa9acacdaf5ad095060dc62f4dc16c2'))
+describe("URN Utils", () => {
+  it("should return true for valid urns", () => {
+    const urn = 'pbk:rsa:2048:cb47e6aada931986bb6bbf02c8618437c072cefa4e19c1ee6cb189b95a49e3ce94fb4de129c30ab7e683f827c98eb05e844af24f809ed5f217e93c14d58f64b98fc9136d3c2b56a672853a8f52c7ac7acd201b09d0f578f32f377f954905e18fa360448901d0ac538cd1102dc0821cd13a843e370471c00e95daf4bba001186c5b2220e15f2f4777aa9b0a823186c34d82fd557e245b4d5816f48bdc09dd34806982609b63012dd13fe603f23730940e68463b1b68f24ee77907925d286d55ec22bad53119f8354388e051854ef436589538f1efbf104af477dc3ca2cf29974fcf432639b8716c38c717d44c8f0c90d59f02f2ab0aef8b59c2feb460e2cbfb57010001';
+    const urn2 = 'pbk:ec:secp256r1:0260fed4ba255a9d31c961eb74c6356d68c049b8923b61fa6ce669622e60f29fb6'
+    should(utils.urn.check(urn)).equal(true);
+    should(utils.urn.check(urn2)).equal(true);
+  });
 
-console.log('');
-console.log('Generate new key pair');
-var newKeyPair = utils.keyPair.generate('secp256r1');
-console.log('newKeyPair: ',newKeyPair);
-
-var pubKeyCompress = utils.ec.compress(newKeyPair.ecpubhex);
-console.log('pubKeyCompress from newKeyPair:',pubKeyCompress);
-
-var newURN = utils.urn.create('pbk',['ec','secp256r1'],pubKeyCompress);
-console.log('newURN from pubKeyCompress:',newURN);
-
-// RSA
-console.log('Verify RSA:','e3ecf72fa4143b3416154b62d0b570609d13f080 ; 2f6b41e6091269af8782b0b3e62f00cadd9c724c4ed50fd1c5f04bb1ea45796d71192ea297b0b1c161ae619243eecaaf20794e0abc397705e357941435fcdbcf45b9dc955ae5a366eb4b991a947941f0a94e41b81c4c13453f0ca0230ba6063d7f79f437c2ea26db40d6eafaecf6df7565b6a7673b05d5c5ff6d9420c4acb72a8905f6f79e9026940ce9c8d38c96dbf5a0388d3965caea316456553fbf4818c12c213c88015eaf2930148d7b23a57a71994bdea5113f661a24b6fe74d6fd347d41a0c63638be28f8410d4c1cd441fc38b5a0d4bbee1410babe5b4e5768a55f1f321354acecaf9e14981434bbe1c72fcfb0153b94141f6c48198f3890f95e8ce3 ; pbk:rsa:2048:cb47e6aada931986bb6bbf02c8618437c072cefa4e19c1ee6cb189b95a49e3ce94fb4de129c30ab7e683f827c98eb05e844af24f809ed5f217e93c14d58f64b98fc9136d3c2b56a672853a8f52c7ac7acd201b09d0f578f32f377f954905e18fa360448901d0ac538cd1102dc0821cd13a843e370471c00e95daf4bba001186c5b2220e15f2f4777aa9b0a823186c34d82fd557e245b4d5816f48bdc09dd34806982609b63012dd13fe603f23730940e68463b1b68f24ee77907925d286d55ec22bad53119f8354388e051854ef436589538f1efbf104af477dc3ca2cf29974fcf432639b8716c38c717d44c8f0c90d59f02f2ab0aef8b59c2feb460e2cbfb57010001');
-var urn = 'pbk:rsa:2048:cb47e6aada931986bb6bbf02c8618437c072cefa4e19c1ee6cb189b95a49e3ce94fb4de129c30ab7e683f827c98eb05e844af24f809ed5f217e93c14d58f64b98fc9136d3c2b56a672853a8f52c7ac7acd201b09d0f578f32f377f954905e18fa360448901d0ac538cd1102dc0821cd13a843e370471c00e95daf4bba001186c5b2220e15f2f4777aa9b0a823186c34d82fd557e245b4d5816f48bdc09dd34806982609b63012dd13fe603f23730940e68463b1b68f24ee77907925d286d55ec22bad53119f8354388e051854ef436589538f1efbf104af477dc3ca2cf29974fcf432639b8716c38c717d44c8f0c90d59f02f2ab0aef8b59c2feb460e2cbfb57010001';
-var urnWithoutExponent = urn.slice(0, -6);
-var challenge = 'e3ecf72fa4143b3416154b62d0b570609d13f080';
-var wrongChallenge = 'e3ecf72fa4143b3416154b62d0b570609d13f081';
-var signature = '2f6b41e6091269af8782b0b3e62f00cadd9c724c4ed50fd1c5f04bb1ea45796d71192ea297b0b1c161ae619243eecaaf20794e0abc397705e357941435fcdbcf45b9dc955ae5a366eb4b991a947941f0a94e41b81c4c13453f0ca0230ba6063d7f79f437c2ea26db40d6eafaecf6df7565b6a7673b05d5c5ff6d9420c4acb72a8905f6f79e9026940ce9c8d38c96dbf5a0388d3965caea316456553fbf4818c12c213c88015eaf2930148d7b23a57a71994bdea5113f661a24b6fe74d6fd347d41a0c63638be28f8410d4c1cd441fc38b5a0d4bbee1410babe5b4e5768a55f1f321354acecaf9e14981434bbe1c72fcfb0153b94141f6c48198f3890f95e8ce3';
-
-console.log('should be true:', utils.rsa.verify(urn, challenge, signature));
-console.log('should be true:', utils.rsa.verify(urnWithoutExponent, challenge, signature));
-console.log('should be false:', utils.rsa.verify(urn, wrongChallenge, signature));
-
-
-// URN
-console.log('should be true:', utils.urn.check(urn));
-console.log('should be error message:', utils.urn.check('pbk'));
-console.log('should be error message:', utils.urn.check('pbk:'));
-console.log('should be error message:', utils.urn.check('pbk::ec'));
-console.log('should be error message:', utils.urn.check(':pbk:ec'));
-console.log('should be error message:', utils.urn.check(':'));
-console.log('should be error message:', utils.urn.check(''));
-console.log('should be error message:', utils.urn.check('pbk:ec:secp256r11'));
-console.log('should be error message:', utils.urn.check('pbk:ec:secp256r1'));
-console.log('should be error message:', utils.urn.check('pbk:ec:secp256r1:something:id'));
-console.log('should be error message:', utils.urn.check('pbk:ec:secp256r2:123'));
-console.log('should be error message:', utils.urn.check('pbk:rsa:20480'));
-console.log('should be error message:', utils.urn.check('pbk:rsa:2048'));
-console.log('should be error message:', utils.urn.check('pbk:rsa:2048:something:id'));
-console.log('should be error message:', utils.urn.check('pbk:rsa:512'));
-console.log('should be error message:', utils.urn.check('ble:1.01'));
-console.log('should be error message:', utils.urn.check('ble:1.0'));
-console.log('should be error message:', utils.urn.check('ble:3.0'));
-console.log('should be error message:', utils.urn.check('ble:1.0:whatever:11223344'));
-console.log('should be error message:', utils.urn.check('nfc:1.01'));
-console.log('should be error message:', utils.urn.check('nfc:1.0'));
-console.log('should be error message:', utils.urn.check('nfc:1.0:something:id'));
-console.log('should be error message:', utils.urn.check('nfc:2.0'));
-console.log('should be error message:', utils.urn.check('snu:123'));
-console.log('should be error message:', utils.urn.check('sn:'));
-console.log('should be error message:', utils.urn.check('sn:something:id'));
-console.log('should be error message:', utils.urn.check('sn'));
-console.log('should be true:', utils.urn.check('pbk:ec:secp256r1:0260fed4ba255a9d31c961eb74c6356d68c049b8923b61fa6ce669622e60f29fb6'));
-console.log('should be error message:', utils.urn.check('pbk:rsa:2048:123'));
-console.log('should be error message:', utils.urn.check('ble:1.0:123'));
-console.log('should be error message:', utils.urn.check('nfc:1.0:123'));
-console.log('should be error message:', utils.urn.check('sn:123'));
+  it("should return a string message for invalid urns", () => {
+    should(utils.urn.check('pbk')).be.String();
+    // should(utils.urn.check('pbk:')).be.String();
+    // should(utils.urn.check('pbk::ec')).be.String();
+    // should(utils.urn.check(':pbk:ec')).be.String();
+    // should(utils.urn.check(':')).be.String();
+    // should(utils.urn.check('')).be.String();
+    // should(utils.urn.check('pbk:ec:secp256r11')).be.String();
+    // should(utils.urn.check('pbk:ec:secp256r1')).be.String();
+    // should(utils.urn.check('pbk:ec:secp256r1:something:id')).be.String();
+    // should(utils.urn.check('pbk:ec:secp256r2:123')).be.String();
+    // should(utils.urn.check('pbk:rsa:20480')).be.String();
+    // should(utils.urn.check('pbk:rsa:2048')).be.String();
+    // should(utils.urn.check('pbk:rsa:2048:something:id')).be.String();
+    // should(utils.urn.check('pbk:rsa:512')).be.String();
+    // should(utils.urn.check('ble:1.01')).be.String();
+    // should(utils.urn.check('ble:1.0')).be.String();
+    // should(utils.urn.check('ble:3.0')).be.String();
+    // should(utils.urn.check('ble:1.0:whatever:11223344')).be.String();
+    // should(utils.urn.check('nfc:1.01')).be.String();
+    // should(utils.urn.check('nfc:1.0')).be.String();
+    // should(utils.urn.check('nfc:1.0:something:id')).be.String();
+    // should(utils.urn.check('nfc:2.0')).be.String();
+    // should(utils.urn.check('snu:123')).be.String();
+    // should(utils.urn.check('sn:')).be.String();
+    // should(utils.urn.check('sn:something:id')).be.String();
+    // should(utils.urn.check('sn')).be.String();
+    // should(utils.urn.check('pbk:rsa:2048:123')).be.String();
+    // should(utils.urn.check('ble:1.0:123')).be.String();
+    // should(utils.urn.check('nfc:1.0:123')).be.String();
+    // should(utils.urn.check('sn:123')).be.String();
+  });
+});


### PR DESCRIPTION
- Amends tests to use mocha and should.js
- refactors URN check to only enforce URN format validity
- Amends EC verification to support additional curves